### PR TITLE
The type of the field should always be preferred

### DIFF
--- a/gwt-jackson/src/main/java/com/github/nmorel/gwtjackson/rebind/property/PropertyProcessor.java
+++ b/gwt-jackson/src/main/java/com/github/nmorel/gwtjackson/rebind/property/PropertyProcessor.java
@@ -384,12 +384,12 @@ public final class PropertyProcessor {
     private static JType findType( TreeLogger logger, PropertyAccessors fieldAccessors, JacksonTypeOracle typeOracle ) throws
             UnableToCompleteException {
         JType type;
-        if ( fieldAccessors.getGetter().isPresent() ) {
+        if ( fieldAccessors.getField().isPresent() ) {
+            type = fieldAccessors.getField().get().getType();
+        } else if ( fieldAccessors.getGetter().isPresent() ) {
             type = fieldAccessors.getGetter().get().getReturnType();
         } else if ( fieldAccessors.getSetter().isPresent() ) {
             type = fieldAccessors.getSetter().get().getParameters()[0].getType();
-        } else if ( fieldAccessors.getField().isPresent() ) {
-            type = fieldAccessors.getField().get().getType();
         } else if ( fieldAccessors.getParameter().isPresent() ) {
             type = fieldAccessors.getParameter().get().getType();
         } else {


### PR DESCRIPTION
All methods of a class are considered getter methods in gwt-jackson, the only condition is that they have a single parameter. This is of course ridiculous. 

Then, when getter visibility is NONE and only the field should be used, the type is still taken from the nonsense getter method that was detected. This hack switches to the field type first if there is a field, tests pass.